### PR TITLE
fix: only fields with rows def should preserve new line ( MAPCO-3632 )

### DIFF
--- a/src/discrete-layer/components/layer-details/field-value-presentors/form.input.text.field.tsx
+++ b/src/discrete-layer/components/layer-details/field-value-presentors/form.input.text.field.tsx
@@ -32,13 +32,14 @@ interface FormInputTextFieldProps {
 export const FormInputTextFieldComponent: React.FC<FormInputTextFieldProps> = ({mode, fieldInfo, value, formik, type}) => {
   const intl = useIntl();
   const isCopyable = fieldInfo.isCopyable ?? false;
+  const isPreserveNewLine = fieldInfo.rows ?? false;
   const [innerValue, handleOnChange] = useDebounceField(formik as EntityFormikHandlers , value ?? '');
 
   if (formik === undefined || mode === Mode.VIEW || (mode === Mode.EDIT && fieldInfo.isManuallyEditable !== true)) {
     return (
       <>
         <TooltippedValue
-          className={`detailsFieldValue ${isCopyable ? 'detailFieldCopyable' : ''}`}>
+          className={`detailsFieldValue ${isCopyable ? 'detailFieldCopyable' : ''} ${isPreserveNewLine ? 'preserveNewline' : ''}`}>
           {innerValue}
         </TooltippedValue>
         {

--- a/src/discrete-layer/components/layer-details/layer-details.css
+++ b/src/discrete-layer/components/layer-details/layer-details.css
@@ -69,6 +69,9 @@
   padding: 0 1px;
   margin: 0 2px;
   text-align: left;
+}
+
+.preserveNewline {
   white-space: pre-line;
 }
 


### PR DESCRIPTION
Only fields with **rows** definition should preserve new-line(s)