### PR TITLE
fix: add 'scrollToIndex' to react-virtualized <List/> and convert expandedParts to false

### DIFF
--- a/src/discrete-layer/components/layer-details/raster/layer-datails-form.raster.tsx
+++ b/src/discrete-layer/components/layer-details/raster/layer-datails-form.raster.tsx
@@ -856,6 +856,7 @@ export const InnerRasterForm = (
                     rowCount={expandedParts.length}
                     overscanRowCount={3}
                     rowHeight={(idx)=> ( expandedParts[idx.index] ? 316 : 48 )}
+                    scrollToIndex = { expandedParts.length - 1 }
                   />
               }
               {
@@ -874,7 +875,7 @@ export const InnerRasterForm = (
 
                       schemaUpdater(1, lastPartIdx);
                    
-                      setExpandedParts([...expandedParts, false]);
+                      setExpandedParts([...expandedParts.fill(false), true]);
 
                       const polygonData = {
                         uniquePartId: NESTED_FORMS_PRFIX + lastPartIdx,


### PR DESCRIPTION
add 'scrollToIndex' to react-virtualized <List/> and convert all expandedParts to false when adding a new part