### PR TITLE
fix: pp date label field rename and intersect crash ( MAPCO-7054 ,  MAPCO-7056 )

### DIFF
--- a/.github/workflows/Main.yaml
+++ b/.github/workflows/Main.yaml
@@ -11,13 +11,13 @@ jobs:
         node-version: [16.13.x]
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install yarn

--- a/src/discrete-layer/components/layer-details/raster/pp-extent-vector-layer.tsx
+++ b/src/discrete-layer/components/layer-details/raster/pp-extent-vector-layer.tsx
@@ -159,14 +159,19 @@ export const PolygonPartsVectorLayer: React.FC<PolygonPartsVectorLayerProps> = o
             const bbox = bboxPolygon(mapOl.getView().calculateExtent([size[0] + BUFFER,size[1] + BUFFER]) as BBox);
             const extentPolygon = polygon(bbox.geometry.coordinates);
             
-            //@ts-ignore
-            const featureClippedPolygon = intersect(feat, extentPolygon);
-           
-            if (featureClippedPolygon) {
-              const geometry = new GeoJSON().readGeometry(featureClippedPolygon.geometry);
-              greenStyle.setGeometry(geometry);
-            }
+            try{ // There is some cases when turf.intersect() throws exception, then no need to change geometry
+              // @ts-ignore
+              const featureClippedPolygon = intersect(feat, extentPolygon);
 
+              if (featureClippedPolygon) {
+                const geometry = new GeoJSON().readGeometry(featureClippedPolygon.geometry);
+                greenStyle.setGeometry(geometry);
+              }
+            }
+            catch(e){
+              console.log('*** PP: turf.intersect() failed ***', 'feat -->',feat, 'extentPolygon -->',extentPolygon);
+            }
+           
             return feat ? <GeoJSONFeature 
               geometry={{...feat.geometry}} 
               fit={false}

--- a/src/discrete-layer/components/layer-details/raster/pp-map.utils.ts
+++ b/src/discrete-layer/components/layer-details/raster/pp-map.utils.ts
@@ -143,7 +143,7 @@ const getText = (feature: Feature, resolution: number, featureConfig: Record<str
   const zoomLevel = Object.values(ZOOM_LEVELS_TABLE)
     .map((res) => res.toString())
     .findIndex(val => val === get(feature.properties, 'resolutionDegree')?.toString())
-  const ingestionDateUTC = dateFormatter(get(feature.properties, 'ingestionDateUtc'), false);
+  const ingestionDateUTC = dateFormatter(get(feature.properties, 'imagingTimeEndUTC'), false);
   const updatedInVersion = get(feature.properties, 'productVersion');
 
   let text = defaultText ?? '';


### PR DESCRIPTION
1. pp-part label date part was missing. **imagingTimeEndUTC** should be used
2. while debugging a code in OUTNET comes that turf.intersect() may throw an exception